### PR TITLE
RunOnFxThread annotation and Interceptor

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -24,6 +24,11 @@
       <artifactId>quarkus-junit5-internal</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/deployment/src/main/java/io/quarkiverse/fx/deployment/QuarkusFxExtensionProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/fx/deployment/QuarkusFxExtensionProcessor.java
@@ -1,14 +1,26 @@
 package io.quarkiverse.fx.deployment;
 
+import java.util.Collection;
+import java.util.function.Consumer;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.VoidType;
+import org.jboss.logging.Logger;
+
 import io.quarkiverse.fx.FXMLLoaderProducer;
 import io.quarkiverse.fx.PrimaryStage;
+import io.quarkiverse.fx.RunOnFxThread;
+import io.quarkiverse.fx.RunOnFxThreadInterceptor;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 
 class QuarkusFxExtensionProcessor {
 
     private static final String FEATURE = "quarkus-fx";
+    private static final Logger LOGGER = Logger.getLogger(QuarkusFxExtensionProcessor.class);
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -23,5 +35,30 @@ class QuarkusFxExtensionProcessor {
     @BuildStep
     AdditionalBeanBuildItem primaryStage() {
         return new AdditionalBeanBuildItem(PrimaryStage.class);
+    }
+
+    @BuildStep
+    AdditionalBeanBuildItem runOnFxThreadInterceptor(CombinedIndexBuildItem combinedIndex) {
+        runOnFxThreadInterceptorChecker(combinedIndex);
+        return new AdditionalBeanBuildItem(RunOnFxThread.class, RunOnFxThreadInterceptor.class);
+    }
+
+    void runOnFxThreadInterceptorChecker(CombinedIndexBuildItem combinedIndex) {
+        Consumer<AnnotationTarget> methodChecker = target -> {
+            if (!(target.asMethod().returnType() instanceof VoidType)) {
+                LOGGER.warnf("Method %s annotated with %s return value will be lost, set return type to void",
+                        target.asMethod().name(),
+                        RunOnFxThread.class.getSimpleName());
+            }
+        };
+
+        Collection<AnnotationInstance> annotations = combinedIndex.getComputingIndex().getAnnotations(RunOnFxThread.class);
+        for (AnnotationInstance annotation : annotations) {
+            AnnotationTarget target = annotation.target();
+            switch (target.kind()) {
+                case METHOD -> methodChecker.accept(target);
+                case CLASS -> target.asClass().methods().forEach(methodChecker);
+            }
+        }
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/fx/deployment/QuarkusFxExtensionProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/fx/deployment/QuarkusFxExtensionProcessor.java
@@ -39,11 +39,6 @@ class QuarkusFxExtensionProcessor {
 
     @BuildStep
     AdditionalBeanBuildItem runOnFxThreadInterceptor(CombinedIndexBuildItem combinedIndex) {
-        runOnFxThreadInterceptorChecker(combinedIndex);
-        return new AdditionalBeanBuildItem(RunOnFxThread.class, RunOnFxThreadInterceptor.class);
-    }
-
-    void runOnFxThreadInterceptorChecker(CombinedIndexBuildItem combinedIndex) {
         Consumer<AnnotationTarget> methodChecker = target -> {
             if (!(target.asMethod().returnType() instanceof VoidType)) {
                 LOGGER.warnf("Method %s annotated with %s return value will be lost, set return type to void",
@@ -60,5 +55,8 @@ class QuarkusFxExtensionProcessor {
                 case CLASS -> target.asClass().methods().forEach(methodChecker);
             }
         }
+
+        return new AdditionalBeanBuildItem(RunOnFxThread.class, RunOnFxThreadInterceptor.class);
     }
+
 }

--- a/deployment/src/test/java/io/quarkiverse/fx/deployment/RunOnFxThreadTest.java
+++ b/deployment/src/test/java/io/quarkiverse/fx/deployment/RunOnFxThreadTest.java
@@ -60,16 +60,14 @@ public class RunOnFxThreadTest {
             Observer.OBSERVED_STAGE.set(stage);
         }
 
-        //tag::docs[]
-        void doOnCurrentThread() {//<1>
+        void doOnCurrentThread() {
             DO_ON_CURRENT_METHOD_THREAD = Thread.currentThread().getName();
         }
 
         @RunOnFxThread
-        void doOnFxThread() {//<2>
+        void doOnFxThread() {
             DO_ON_FX_METHOD_THREAD = Thread.currentThread().getName();
         }
-        //end::docs[]
 
         public static boolean stageObserved() {
             return OBSERVED_STAGE.get() != null;

--- a/deployment/src/test/java/io/quarkiverse/fx/deployment/RunOnFxThreadTest.java
+++ b/deployment/src/test/java/io/quarkiverse/fx/deployment/RunOnFxThreadTest.java
@@ -1,0 +1,77 @@
+package io.quarkiverse.fx.deployment;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.fx.FxApplication;
+import io.quarkiverse.fx.PrimaryStage;
+import io.quarkiverse.fx.RunOnFxThread;
+import io.quarkus.test.QuarkusUnitTest;
+import javafx.application.Application;
+import javafx.stage.Stage;
+
+public class RunOnFxThreadTest {
+
+    private static final int LAUNCH_TIMEOUT_MS = 1_000;
+    public static final String JAVA_FX_APPLICATION_THREAD = "JavaFX Application Thread";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar.addClasses(Observer.class));
+
+    @Test
+    void annotatedMethodsExecuteOnFxThread() {
+        // launch
+        CompletableFuture.runAsync(() -> Application.launch(FxApplication.class));
+        // wait for stage to be observed
+        Awaitility.await().atMost(LAUNCH_TIMEOUT_MS, TimeUnit.MILLISECONDS).until(Observer::stageObserved);
+        // stage should not be null
+        Assertions.assertNotNull(Observer.OBSERVED_STAGE.get());
+        //
+        Assertions.assertEquals(JAVA_FX_APPLICATION_THREAD, Observer.STAGE_OBSERVER_METHOD_THREAD);
+        Assertions.assertNotEquals(JAVA_FX_APPLICATION_THREAD, Observer.DO_ON_CURRENT_METHOD_THREAD);
+        Assertions.assertEquals(JAVA_FX_APPLICATION_THREAD, Observer.DO_ON_FX_METHOD_THREAD);
+    }
+
+    @Dependent
+    static class Observer {
+        public static final AtomicReference<Stage> OBSERVED_STAGE = new AtomicReference<>();
+        public static String STAGE_OBSERVER_METHOD_THREAD;
+        public static String DO_ON_CURRENT_METHOD_THREAD;
+        public static String DO_ON_FX_METHOD_THREAD;
+
+        public void observeStage(@Observes @PrimaryStage final Stage stage) throws ExecutionException, InterruptedException {
+            // Observe current thread
+            STAGE_OBSERVER_METHOD_THREAD = Thread.currentThread().getName();
+            // launch methods and observe threads
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            executor.submit(this::doOnCurrentThread).get();
+            executor.submit(this::doOnFxThread).get();
+            executor.shutdownNow();
+            // observe stage
+            Observer.OBSERVED_STAGE.set(stage);
+        }
+
+        void doOnCurrentThread() {
+            DO_ON_CURRENT_METHOD_THREAD = Thread.currentThread().getName();
+        }
+
+        @RunOnFxThread
+        void doOnFxThread() {
+            DO_ON_FX_METHOD_THREAD = Thread.currentThread().getName();
+        }
+
+        public static boolean stageObserved() {
+            return OBSERVED_STAGE.get() != null;
+        }
+    }
+
+}

--- a/deployment/src/test/java/io/quarkiverse/fx/deployment/RunOnFxThreadTest.java
+++ b/deployment/src/test/java/io/quarkiverse/fx/deployment/RunOnFxThreadTest.java
@@ -60,14 +60,16 @@ public class RunOnFxThreadTest {
             Observer.OBSERVED_STAGE.set(stage);
         }
 
-        void doOnCurrentThread() {
+        //tag::docs[]
+        void doOnCurrentThread() {//<1>
             DO_ON_CURRENT_METHOD_THREAD = Thread.currentThread().getName();
         }
 
         @RunOnFxThread
-        void doOnFxThread() {
+        void doOnFxThread() {//<2>
             DO_ON_FX_METHOD_THREAD = Thread.currentThread().getName();
         }
+        //end::docs[]
 
         public static boolean stageObserved() {
             return OBSERVED_STAGE.get() != null;

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,1 +1,2 @@
 * xref:index.adoc[Quarkus FX]
+* xref:run-on-fx-thread.adoc[]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,5 @@
 = Quarkus FX
-include::./includes/attributes.adoc[]
+include::../includes/attributes.adoc[]
 
 :extension-status: experimental
 

--- a/docs/modules/ROOT/pages/run-on-fx-thread.adoc
+++ b/docs/modules/ROOT/pages/run-on-fx-thread.adoc
@@ -1,0 +1,14 @@
+= @RunOnFxThread
+include::../includes/attributes.adoc[]
+
+`@RunOnFxThread` annotation offers for a convenient way to execute the target on JavaFx UI thread (JavaFX Application Thread).
+
+Annotation can be applied on method level or on class level (to mark all methods within a class)
+
+
+[source,java, indent=0]
+----
+include::../../../../deployment/src/test/java/io/quarkiverse/fx/deployment/RunOnFxThreadTest.java[tag=docs]
+----
+<1> `doOnCurrentThread` method will be executed in whatever thread it was called from
+<2> `doOnFxThread` method will be executed on JavaFx UI thread (JavaFX Application Thread)

--- a/docs/modules/ROOT/pages/run-on-fx-thread.adoc
+++ b/docs/modules/ROOT/pages/run-on-fx-thread.adoc
@@ -5,10 +5,30 @@ include::../includes/attributes.adoc[]
 
 Annotation can be applied on method level or on class level (to mark all methods within a class)
 
+- Example
 
 [source,java, indent=0]
 ----
-include::../../../../deployment/src/test/java/io/quarkiverse/fx/deployment/RunOnFxThreadTest.java[tag=docs]
+VBox vBox = new VBox();
+
+public void start(@Observes @PrimaryStage final Stage stage) {
+    Scene scene = new Scene(vBox);
+    stage.setScene(scene);
+    stage.show();
+
+    try (ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor()) {
+        executorService.submit(() -> showNode(createExpensiveNode()));
+    }
+}
+
+Node createExpensiveNode() {//<1>
+    return new Label(LocalTime.now().toString());
+}
+
+@RunOnFxThread
+void showNode(Node node) {//<2>
+    vBox.getChildren().add(node);
+}
 ----
-<1> `doOnCurrentThread` method will be executed in whatever thread it was called from
-<2> `doOnFxThread` method will be executed on JavaFx UI thread (JavaFX Application Thread)
+<1> `createExpensiveNode` method will be executed in a thread from executor service
+<2> `showNode` method will be executed on JavaFx UI thread (JavaFX Application Thread)

--- a/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThread.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThread.java
@@ -1,6 +1,10 @@
 package io.quarkiverse.fx;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 import jakarta.interceptor.InterceptorBinding;
 

--- a/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThread.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThread.java
@@ -8,6 +8,10 @@ import java.lang.annotation.Target;
 
 import jakarta.interceptor.InterceptorBinding;
 
+/**
+ * Mark annotated target to be executed on JavaFx UI Thread (JavaFX Application Thread),
+ * passing the target as a runnable to {@link javafx.application.Platform#runLater(Runnable)}
+ */
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })

--- a/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThread.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThread.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.fx;
+
+import java.lang.annotation.*;
+
+import jakarta.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Inherited
+public @interface RunOnFxThread {
+}

--- a/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThreadInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThreadInterceptor.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.fx;
+
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import org.jboss.logging.Logger;
+
+import javafx.application.Platform;
+
+@Interceptor
+@RunOnFxThread
+public class RunOnFxThreadInterceptor {
+
+    private static final Logger LOGGER = Logger.getLogger(RunOnFxThreadInterceptor.class);
+
+    @AroundInvoke
+    public Object runOnFxThread(InvocationContext ctx) throws Exception {
+        LOGGER.tracef("intercepted %s on thread %s", ctx.getMethod(), Thread.currentThread());
+        if (Platform.isFxApplicationThread()) {
+            return ctx.proceed();
+        } else {
+            Platform.runLater(() -> {
+                try {
+                    ctx.proceed();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
`@RunOnFxThread` annotation and interceptor to run methods on JavaFx's UI thread  `JavaFX Application Thread` inspired by [Gluon Ignite](https://github.com/gluonhq/ignite)

- Example usage
```java
VBox vBox = new VBox();

public void start(@Observes @PrimaryStage final Stage stage) {
    Scene scene = new Scene(vBox);
    stage.setScene(scene);
    stage.show();

    try (ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor()) {
        for (int i = 0; i < 10; i++) {
            executorService.submit(() -> showNode(createExpensiveNode()));
        }
    }
}

Node createExpensiveNode() {
    try {
        TimeUnit.SECONDS.sleep(3);
    } catch (Exception e) {
        e.printStackTrace();
    }
    return new Label(LocalTime.now().toString());
}

@RunOnFxThread
void showNode(Node node) {
    vBox.getChildren().add(node);
}
```