### PR TITLE
Use Quarkus LTS version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <module>runtime</module>
   </modules>
   <properties>
-    <quarkus.version>3.6.7</quarkus.version>
+    <quarkus.version>3.2.10.Final</quarkus.version>
     <javafx.version>17.0.10</javafx.version>
     <maven.compiler.release>17</maven.compiler.release>
   </properties>


### PR DESCRIPTION
Using the Quarkus LTS (Long-term Support) version is preferred
