### PR TITLE
Add a countdown latch as a startup barrier for use by the RunOnFxThreadInterceptor

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/fx/deployment/QuarkusFxExtensionProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/fx/deployment/QuarkusFxExtensionProcessor.java
@@ -40,9 +40,24 @@ class QuarkusFxExtensionProcessor {
         return new AdditionalBeanBuildItem(FXMLLoaderProducer.class);
     }
 
+    /**
+     * Register the PrimaryStage qualifier
+     *
+     * @return build item for PrimaryStage
+     */
     @BuildStep
     AdditionalBeanBuildItem primaryStage() {
-        return new AdditionalBeanBuildItem(PrimaryStage.class, FxApplication.class);
+        return new AdditionalBeanBuildItem(PrimaryStage.class);
+    }
+
+    /**
+     * Register the FxApplication so the startup latch producer method is found
+     *
+     * @return build item for FxApplication
+     */
+    @BuildStep
+    AdditionalBeanBuildItem fxApplication() {
+        return new AdditionalBeanBuildItem(FxApplication.class);
     }
 
     @BuildStep

--- a/deployment/src/main/java/io/quarkiverse/fx/deployment/QuarkusFxExtensionProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/fx/deployment/QuarkusFxExtensionProcessor.java
@@ -10,12 +10,7 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jandex.VoidType;
 import org.jboss.logging.Logger;
 
-import io.quarkiverse.fx.FXMLLoaderProducer;
-import io.quarkiverse.fx.FxApplication;
-import io.quarkiverse.fx.PrimaryStage;
-import io.quarkiverse.fx.QuarkusFxApplication;
-import io.quarkiverse.fx.RunOnFxThread;
-import io.quarkiverse.fx.RunOnFxThreadInterceptor;
+import io.quarkiverse.fx.*;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -56,8 +51,8 @@ class QuarkusFxExtensionProcessor {
      * @return build item for FxApplication
      */
     @BuildStep
-    AdditionalBeanBuildItem fxApplication() {
-        return new AdditionalBeanBuildItem(FxApplication.class);
+    AdditionalBeanBuildItem startupLatch() {
+        return new AdditionalBeanBuildItem(StartupLatch.class);
     }
 
     @BuildStep

--- a/deployment/src/main/java/io/quarkiverse/fx/deployment/QuarkusFxExtensionProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/fx/deployment/QuarkusFxExtensionProcessor.java
@@ -11,6 +11,7 @@ import org.jboss.jandex.VoidType;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.fx.FXMLLoaderProducer;
+import io.quarkiverse.fx.FxApplication;
 import io.quarkiverse.fx.PrimaryStage;
 import io.quarkiverse.fx.QuarkusFxApplication;
 import io.quarkiverse.fx.RunOnFxThread;
@@ -41,7 +42,7 @@ class QuarkusFxExtensionProcessor {
 
     @BuildStep
     AdditionalBeanBuildItem primaryStage() {
-        return new AdditionalBeanBuildItem(PrimaryStage.class);
+        return new AdditionalBeanBuildItem(PrimaryStage.class, FxApplication.class);
     }
 
     @BuildStep

--- a/runtime/src/main/java/io/quarkiverse/fx/FxApplication.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/FxApplication.java
@@ -2,6 +2,7 @@ package io.quarkiverse.fx;
 
 import java.util.concurrent.CountDownLatch;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.util.AnnotationLiteral;
@@ -9,11 +10,13 @@ import jakarta.enterprise.util.AnnotationLiteral;
 import javafx.application.Application;
 import javafx.stage.Stage;
 
+@ApplicationScoped
 public class FxApplication extends Application {
     private static CountDownLatch started = new CountDownLatch(1);
 
     /**
      * A producer for the FxApplication.started CountDownLatch
+     *
      * @return FxApplication.started CountDownLatch
      */
     @Produces
@@ -31,7 +34,7 @@ public class FxApplication extends Application {
                 .select(new AnnotationLiteral<PrimaryStage>() {
                 })
                 .fire(primaryStage);
-        // Mark that the applciation start has finished.
+        // Mark that the application has finished starting.
         started.countDown();
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/fx/FxApplication.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/FxApplication.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.fx;
 
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.util.AnnotationLiteral;
 
@@ -7,6 +10,17 @@ import javafx.application.Application;
 import javafx.stage.Stage;
 
 public class FxApplication extends Application {
+    private static CountDownLatch started = new CountDownLatch(1);
+
+    /**
+     * A producer for the FxApplication.started CountDownLatch
+     * @return FxApplication.started CountDownLatch
+     */
+    @Produces
+    @PrimaryStage
+    CountDownLatch produceStartedFlag() {
+        return started;
+    }
 
     @Override
     public void start(final Stage primaryStage) {
@@ -17,5 +31,7 @@ public class FxApplication extends Application {
                 .select(new AnnotationLiteral<PrimaryStage>() {
                 })
                 .fire(primaryStage);
+        // Mark that the applciation start has finished.
+        started.countDown();
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/fx/PrimaryStage.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/PrimaryStage.java
@@ -6,6 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import jakarta.inject.Qualifier;
+
 import javafx.stage.Stage;
 
 /**

--- a/runtime/src/main/java/io/quarkiverse/fx/PrimaryStage.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/PrimaryStage.java
@@ -6,9 +6,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import jakarta.inject.Qualifier;
+import javafx.stage.Stage;
 
+/**
+ * This is used as a qualifier as for receiving the notification main <code>start</code> entry point for all
+ * JavaFX applications has been called.
+ *
+ * It is also used to qualify the CountDownLatch type used by the {@linkplain FxApplication} uses
+ * as a startup notification barrier.
+ *
+ * @see javafx.application.Application#start(Stage)
+ * @see FxApplication#produceStartedFlag()
+ */
 @Qualifier
-@Target(ElementType.PARAMETER)
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PrimaryStage {
 }

--- a/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThreadInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThreadInterceptor.java
@@ -19,14 +19,14 @@ public class RunOnFxThreadInterceptor {
     // The startup latch from FxApplication
     @PrimaryStage
     @Inject
-    CountDownLatch hasStarted;
+    CountDownLatch startupLatch;
 
     @AroundInvoke
     public Object runOnFxThread(final InvocationContext ctx) throws Exception {
         LOGGER.tracef("intercepted %s on thread %s", ctx.getMethod(), Thread.currentThread());
         // Block any thread until the startup latch has been cleared
         // This will return immediately after the FxApplication#start has completed
-        hasStarted.await();
+        startupLatch.await();
 
         if (Platform.isFxApplicationThread()) {
             return ctx.proceed();

--- a/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThreadInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThreadInterceptor.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.fx;
 
-import java.util.concurrent.CountDownLatch;
-
 import jakarta.inject.Inject;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
@@ -16,10 +14,9 @@ import javafx.application.Platform;
 public class RunOnFxThreadInterceptor {
 
     private static final Logger LOGGER = Logger.getLogger(RunOnFxThreadInterceptor.class);
-    // The startup latch from FxApplication
-    @PrimaryStage
+    // The startup latch signalled by FxApplication
     @Inject
-    CountDownLatch hasStarted;
+    StartupLatch hasStarted;
 
     @AroundInvoke
     public Object runOnFxThread(final InvocationContext ctx) throws Exception {

--- a/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThreadInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThreadInterceptor.java
@@ -19,14 +19,14 @@ public class RunOnFxThreadInterceptor {
     // The startup latch from FxApplication
     @PrimaryStage
     @Inject
-    CountDownLatch startupLatch;
+    CountDownLatch hasStarted;
 
     @AroundInvoke
     public Object runOnFxThread(final InvocationContext ctx) throws Exception {
         LOGGER.tracef("intercepted %s on thread %s", ctx.getMethod(), Thread.currentThread());
         // Block any thread until the startup latch has been cleared
         // This will return immediately after the FxApplication#start has completed
-        startupLatch.await();
+        hasStarted.await();
 
         if (Platform.isFxApplicationThread()) {
             return ctx.proceed();

--- a/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThreadInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/RunOnFxThreadInterceptor.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.fx;
 
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.inject.Inject;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
@@ -13,10 +16,18 @@ import javafx.application.Platform;
 public class RunOnFxThreadInterceptor {
 
     private static final Logger LOGGER = Logger.getLogger(RunOnFxThreadInterceptor.class);
+    // The startup latch from FxApplication
+    @PrimaryStage
+    @Inject
+    CountDownLatch hasStarted;
 
     @AroundInvoke
     public Object runOnFxThread(final InvocationContext ctx) throws Exception {
         LOGGER.tracef("intercepted %s on thread %s", ctx.getMethod(), Thread.currentThread());
+        // Block any thread until the startup latch has been cleared
+        // This will return immediately after the FxApplication#start has completed
+        hasStarted.await();
+
         if (Platform.isFxApplicationThread()) {
             return ctx.proceed();
         } else {

--- a/runtime/src/main/java/io/quarkiverse/fx/StartupLatch.java
+++ b/runtime/src/main/java/io/quarkiverse/fx/StartupLatch.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.fx;
+
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.inject.Singleton;
+
+/**
+ * A singleton for a startup latch used by {@linkplain FxApplication} and {@linkplain RunOnFxThreadInterceptor}
+ */
+@Singleton
+public class StartupLatch {
+    private final CountDownLatch started = new CountDownLatch(1);
+
+    public void await() throws InterruptedException {
+        started.await();
+    }
+
+    public void countDown() {
+        started.countDown();
+    }
+}

--- a/samples/using-scheduler/pom.xml
+++ b/samples/using-scheduler/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -12,10 +13,10 @@
     <name>Quarkus FX - Sample - Using Scheduler</name>
 
     <dependencies>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-scheduler</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-scheduler</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkiverse.fx</groupId>
             <artifactId>quarkus-fx</artifactId>

--- a/samples/using-scheduler/pom.xml
+++ b/samples/using-scheduler/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.fx</groupId>
+        <artifactId>quarkus-fx-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-fx-sample-using-scheduler</artifactId>
+    <name>Quarkus FX - Sample - Using Scheduler</name>
+
+    <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-scheduler</artifactId>
+    </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.fx</groupId>
+            <artifactId>quarkus-fx</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/AppController.java
+++ b/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/AppController.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.fx.sample;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import javafx.application.Platform;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.control.Label;
+
+@Dependent
+public class AppController {
+
+    @Inject
+    Instance<FXMLLoader> fxmlLoaderInstance;
+    @FXML
+    private Label timeLabel;
+    @FXML
+    private void initialize() {
+        //
+    }
+
+    public void onMessage(String timeString) {
+        Platform.runLater(() -> timeLabel.setText(timeString));
+    }
+}

--- a/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/AppController.java
+++ b/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/AppController.java
@@ -16,6 +16,7 @@ public class AppController {
     Instance<FXMLLoader> fxmlLoaderInstance;
     @FXML
     private Label timeLabel;
+
     @FXML
     private void initialize() {
         //

--- a/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/ClockEvents.java
+++ b/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/ClockEvents.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.fx.sample;
+
+import java.io.IOException;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+import io.quarkiverse.fx.RunOnFxThread;
+import io.quarkus.logging.Log;
+import io.quarkus.scheduler.Scheduled;
+import javafx.stage.Stage;
+
+/**
+ * A sample CDI bean that receives Quarkus scheduler events that are routed back to the javafx interface
+ */
+@ApplicationScoped
+public class ClockEvents {
+    @Inject
+    UnixTimeProvider timeProvider;
+    @Inject
+    Event<TimeEvent> timeEvent;
+
+    /**
+     * A scheduler callback method that delegates to method that is to be run on the
+     * JavaFX creates an application thread. This allows for better startup behavior
+     * than direct use of javafx.application.Platform#runLater(...) as the interceptor
+     * associated with @RunOnFxThread is able to synchronize with the
+     * {@linkplain io.quarkiverse.fx.FxApplication#start(javafx.stage.Stage)} completion.
+     */
+    @Scheduled(every = "1s")
+    @RunOnFxThread
+    void timeIncrement() {
+        Log.info("timeIncrement");
+        sendTimeEvent();
+    }
+
+    private void sendTimeEvent() {
+        try {
+            long unixTime = timeProvider.getTime();
+            String timeString = String.format("%016x", unixTime);
+            TimeEvent event = new TimeEvent(unixTime, timeString);
+            Log.infof("%d/%s", unixTime, timeString);
+            timeEvent.fireAsync(event);
+        } catch (IOException e) {
+            Log.error("Failed to send TimeEvent", e);
+        }
+    }
+}

--- a/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/ClockEvents.java
+++ b/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/ClockEvents.java
@@ -41,7 +41,7 @@ public class ClockEvents {
             String timeString = String.format("%016x", unixTime);
             TimeEvent event = new TimeEvent(unixTime, timeString);
             Log.infof("%d/%s", unixTime, timeString);
-            timeEvent.fireAsync(event);
+            timeEvent.fire(event);
         } catch (IOException e) {
             Log.error("Failed to send TimeEvent", e);
         }

--- a/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/QuarkusFxApp.java
+++ b/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/QuarkusFxApp.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.fx.sample;
+
+import java.io.InputStream;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.inject.Inject;
+
+import io.quarkiverse.fx.PrimaryStage;
+import io.quarkus.logging.Log;
+import javafx.application.Platform;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+@ApplicationScoped
+public class QuarkusFxApp {
+
+    @Inject
+    FXMLLoader fxmlLoader;
+    private AppController appController;
+
+    public void start(@Observes @PrimaryStage final Stage stage) {
+        Log.info("Begin start");
+        stage.setOnCloseRequest(event -> {
+            Platform.exit();
+            System.exit(0);
+        });
+
+        try {
+            InputStream fxml = this.getClass().getResourceAsStream("/app.fxml");
+            Parent fxmlParent = this.fxmlLoader.load(fxml);
+            appController = this.fxmlLoader.getController();
+
+            Scene scene = new Scene(fxmlParent, 300, 200);
+            stage.setScene(scene);
+            stage.setTitle("Hello Quarkus + JavaFX ! ⏰");
+            stage.show();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        Log.info("End start");
+    }
+
+    void onMessage(@ObservesAsync TimeEvent timeEvent) {
+        Log.infof("Time: %s;%s", timeEvent.unixTime(), timeEvent.timeString());
+        appController.onMessage(timeEvent.timeString());
+    }
+}

--- a/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/QuarkusFxApp.java
+++ b/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/QuarkusFxApp.java
@@ -4,7 +4,6 @@ import java.io.InputStream;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.event.ObservesAsync;
 import jakarta.inject.Inject;
 
 import io.quarkiverse.fx.PrimaryStage;
@@ -44,7 +43,7 @@ public class QuarkusFxApp {
         Log.info("End start");
     }
 
-    void onMessage(@ObservesAsync TimeEvent timeEvent) {
+    void onMessage(@Observes TimeEvent timeEvent) {
         Log.infof("Time: %s;%s", timeEvent.unixTime(), timeEvent.timeString());
         appController.onMessage(timeEvent.timeString());
     }

--- a/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/SystemUnixTimeProvider.java
+++ b/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/SystemUnixTimeProvider.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.fx.sample;
+
+import java.time.Instant;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SystemUnixTimeProvider implements UnixTimeProvider {
+    @Override
+    public long getTime() {
+        return Instant.now().getEpochSecond();
+    }
+}

--- a/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/TimeEvent.java
+++ b/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/TimeEvent.java
@@ -1,0 +1,4 @@
+package io.quarkiverse.fx.sample;
+
+public record TimeEvent(long unixTime, String timeString) {
+}

--- a/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/UnixTimeProvider.java
+++ b/samples/using-scheduler/src/main/java/io/quarkiverse/fx/sample/UnixTimeProvider.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.fx.sample;
+
+import java.io.IOException;
+
+public interface UnixTimeProvider {
+    // Provides the seconds elapsed since the Unix epoch 1970-01-01T00:00:00Z
+    long getTime() throws IOException;
+}

--- a/samples/using-scheduler/src/main/resources/app.fxml
+++ b/samples/using-scheduler/src/main/resources/app.fxml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Copyright (c) 2015, 2019, Gluon and/or its affiliates.
+  All rights reserved. Use is subject to license terms.
+
+  This file is available and licensed under the following license:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the distribution.
+  - Neither the name of Oracle Corporation nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.text.Font?>
+
+
+<TitledPane text="HexClock" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="io.quarkiverse.fx.sample.AppController">
+   <content>
+      <BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="200.0" prefWidth="300.0">
+         <center>
+            <Label fx:id="timeLabel" text="0123456789" BorderPane.alignment="CENTER">
+               <font>
+                  <Font size="24.0" />
+               </font>
+            </Label>
+         </center>
+      </BorderPane>
+   </content>
+</TitledPane>

--- a/samples/using-scheduler/src/main/resources/application.properties
+++ b/samples/using-scheduler/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.log.level=DEBUG

--- a/samples/using-scheduler/src/main/resources/application.properties
+++ b/samples/using-scheduler/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-quarkus.log.level=DEBUG
+# To enable more information about the application startup
+#quarkus.log.level=DEBUG


### PR DESCRIPTION
This avoids race conditions between background threads interacting with javafx.application.Platform thread during startup.

fixes #22