### PR TITLE
Run the tests in separate JVMs

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -43,6 +43,14 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Add a configuration of the surefire plugin to run the tests in separate JVMs to avoid the native library loading problems.

fixes #9